### PR TITLE
Remove index mp4 and only use webm

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
 
 <video autoplay loop poster="/assets/white.png" id="home_back">
 	<source src="Showgoer.mp4" type="video/webm">
-	<source src="Showgoer.webm" type="video/mp4">
+
 </video>
 
 <div id='menu'>


### PR DESCRIPTION
Remove Showgoer video/mp4 from index html. Looks like heroku was throwing an error looking for it.